### PR TITLE
fixed issue in example where sliding scale was in wrong order

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -42,12 +42,12 @@ const SlidingBreakpointContext = createBreakpointContext<
     return ["mob"];
   }
   if (window.innerWidth < 992) {
-    return ["mob", "tab"];
+    return ["tab", "mob"];
   }
   if (window.innerWidth < 1200) {
-    return ["mob", "tab", "desk"];
+    return ["desk", "tab", "mob"];
   }
-  return ["mob", "tab", "desk", "wide"];
+  return ["wide", "desk", "mob", "tab"];
 });
 
 const DetailParagraph = withBreakpointProps(


### PR DESCRIPTION
#1 Fixed issue with sliding scale sample. Breakpoints were in the wrong order. I can see this being an issue for others. Will need to think about whether the order should be reversed. Right now the first item in the array is considered the first breakpoint to match.